### PR TITLE
feat: auto-detect .tool-versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,24 @@ jobs:
       postgres: true
 ```
 
-### Read versions from .tool-versions
+### Auto-detect .tool-versions
+
+If your project has a `.tool-versions` file, it will be used automatically — no configuration needed:
+
+```yaml
+jobs:
+  ci:
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
+```
+
+You can also point to a specific file explicitly:
 
 ```yaml
 jobs:
   ci:
     uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
     with:
-      version-file: '.tool-versions'
+      version-file: 'mise.toml'
 ```
 
 ### Mix with custom jobs

--- a/action.yml
+++ b/action.yml
@@ -42,13 +42,25 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Detect .tool-versions
+      id: detect-versions
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version-file }}" ]; then
+          echo "file=${{ inputs.version-file }}" >> "$GITHUB_OUTPUT"
+        elif [ -z "${{ inputs.otp-version }}" ] && [ -f .tool-versions ]; then
+          echo "file=.tool-versions" >> "$GITHUB_OUTPUT"
+        else
+          echo "file=" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Setup Erlang/OTP & rebar3
       id: setup-beam
       uses: erlef/setup-beam@v1
       with:
         otp-version: ${{ inputs.otp-version }}
         rebar3-version: ${{ inputs.rebar3-version }}
-        version-file: ${{ inputs.version-file || '' }}
+        version-file: ${{ steps.detect-versions.outputs.file }}
         version-type: ${{ inputs.version-type }}
 
     - name: Restore rebar3 cache


### PR DESCRIPTION
## Summary
- Auto-detect `.tool-versions` file when no explicit `otp-version` or `version-file` is set
- Explicit `otp-version` (e.g. from matrix jobs) takes precedence over auto-detection
- Updated README with auto-detect documentation

## Precedence
1. Explicit `version-file` input → use it
2. No `otp-version` AND `.tool-versions` exists → auto-detect
3. Otherwise → use explicit `otp-version`/`rebar3-version`