### PR TITLE
feat: replace Grype with Trivy for SBOM scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
     if: ${{ inputs.enable-sbom }}
     runs-on: ubuntu-24.04
     outputs:
-      grype-json: ${{ steps.grype-extract.outputs.json }}
+      scan-json: ${{ steps.scan-extract.outputs.json }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -407,23 +407,25 @@ jobs:
         run: rebar3 sbom --output bom.xml --force
       - name: Scan SBOM for vulnerabilities
         if: ${{ inputs.enable-sbom-scan }}
-        id: grype
+        id: trivy
         continue-on-error: true
-        uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
-          sbom: bom.xml
-          fail-build: true
-          severity-cutoff: high
-          output-format: json
-          output-file: grype-results.json
+          scan-type: sbom
+          scan-ref: bom.xml
+          format: json
+          output: trivy-results.json
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          trivyignores: .trivyignore
       - name: Extract scan results
         if: ${{ inputs.enable-sbom-scan }}
-        id: grype-extract
+        id: scan-extract
         run: |
-          if [ ! -f grype-results.json ]; then exit 0; fi
-          echo "json<<GRYPE_EOF" >> "$GITHUB_OUTPUT"
-          jq -c '{matches: [.matches[]? | {id: .vulnerability.id, severity: .vulnerability.severity, package: .artifact.name, version: .artifact.version, fix_versions: (.vulnerability.fix.versions // []), fix_state: (.vulnerability.fix.state // "unknown"), url: (.vulnerability.dataSource // "")}]}' grype-results.json >> "$GITHUB_OUTPUT"
-          echo "GRYPE_EOF" >> "$GITHUB_OUTPUT"
+          if [ ! -f trivy-results.json ]; then exit 0; fi
+          echo "json<<SCAN_EOF" >> "$GITHUB_OUTPUT"
+          jq -c '{vulnerabilities: [.Results[]?.Vulnerabilities[]? | {id: .VulnerabilityID, severity: .Severity, package: .PkgName, version: .InstalledVersion, fixed_version: (.FixedVersion // ""), url: (.PrimaryURL // "")}]}' trivy-results.json >> "$GITHUB_OUTPUT"
+          echo "SCAN_EOF" >> "$GITHUB_OUTPUT"
       - name: Upload SBOM
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -431,7 +433,7 @@ jobs:
           name: sbom
           path: bom.xml
       - name: Fail if vulnerabilities found
-        if: ${{ steps.grype.outcome == 'failure' }}
+        if: ${{ steps.trivy.outcome == 'failure' }}
         run: exit 1
 
   dependency-submission:
@@ -478,7 +480,7 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           AUDIT_JSON: ${{ needs.audit.outputs.json }}
-          SBOM_JSON: ${{ needs.sbom.outputs.grype-json }}
+          SBOM_JSON: ${{ needs.sbom.outputs.scan-json }}
         with:
           script: |
             const { renderSummary } = require('./scripts/ci-summary');

--- a/scripts/ci-summary.js
+++ b/scripts/ci-summary.js
@@ -65,26 +65,26 @@ function renderAuditSection(auditJson) {
   return lines;
 }
 
-function renderSbomSection(grypeJson) {
-  if (!grypeJson || !grypeJson.trim()) return null;
+function renderSbomSection(scanJson) {
+  if (!scanJson || !scanJson.trim()) return null;
 
-  let grype;
-  try { grype = JSON.parse(grypeJson); } catch { return null; }
+  let scan;
+  try { scan = JSON.parse(scanJson); } catch { return null; }
 
-  const matches = grype.matches || [];
+  const vulns = scan.vulnerabilities || [];
 
-  if (matches.length === 0) {
+  if (vulns.length === 0) {
     return ['### :package: SBOM Scan', 'No vulnerabilities found.'];
   }
 
   // Deduplicate by vulnerability id + package name
   const seen = new Set();
   const unique = [];
-  for (const m of matches) {
-    const key = `${m.id}:${m.package}`;
+  for (const v of vulns) {
+    const key = `${v.id}:${v.package}`;
     if (!seen.has(key)) {
       seen.add(key);
-      unique.push(m);
+      unique.push(v);
     }
   }
 
@@ -94,12 +94,12 @@ function renderSbomSection(grypeJson) {
   lines.push('| Severity | Package | Version | Vulnerability | Fix |');
   lines.push('|:---:|---|---|---|---|');
 
-  for (const m of unique) {
-    const fix = m.fix_state === 'fixed' && m.fix_versions && m.fix_versions.length > 0
-      ? `Upgrade to \`${m.fix_versions[0]}\``
+  for (const v of unique) {
+    const fix = v.fixed_version
+      ? `Upgrade to \`${v.fixed_version}\``
       : 'No fix available';
-    const vuln = m.url ? `[${m.id}](${m.url})` : m.id;
-    lines.push(`| ${severityLabel(m.severity)} | **${m.package}** | \`${m.version}\` | ${vuln} | ${fix} |`);
+    const vuln = v.url ? `[${v.id}](${v.url})` : v.id;
+    lines.push(`| ${severityLabel(v.severity)} | **${v.package}** | \`${v.version}\` | ${vuln} | ${fix} |`);
   }
 
   return lines;

--- a/scripts/ci-summary.test.js
+++ b/scripts/ci-summary.test.js
@@ -67,7 +67,7 @@ describe('renderSbomSection', () => {
   });
 
   it('renders clean scan', () => {
-    const json = JSON.stringify({ matches: [] });
+    const json = JSON.stringify({ vulnerabilities: [] });
     const lines = renderSbomSection(json);
     assert.ok(Array.isArray(lines));
     const text = lines.join('\n');
@@ -77,13 +77,12 @@ describe('renderSbomSection', () => {
 
   it('renders single vulnerability', () => {
     const json = JSON.stringify({
-      matches: [{
+      vulnerabilities: [{
         id: 'CVE-2025-9999',
         severity: 'Critical',
         package: 'pgo',
         version: '0.14.0',
-        fix_versions: ['0.15.0'],
-        fix_state: 'fixed',
+        fixed_version: '0.15.0',
         url: 'https://nvd.nist.gov/vuln/detail/CVE-2025-9999'
       }]
     });
@@ -99,13 +98,12 @@ describe('renderSbomSection', () => {
 
   it('renders vulnerability with no fix', () => {
     const json = JSON.stringify({
-      matches: [{
+      vulnerabilities: [{
         id: 'CVE-2025-0001',
         severity: 'High',
         package: 'cowlib',
         version: '2.12.0',
-        fix_versions: [],
-        fix_state: 'not-fixed',
+        fixed_version: '',
         url: ''
       }]
     });
@@ -116,12 +114,12 @@ describe('renderSbomSection', () => {
     assert.ok(!text.includes('[CVE-2025-0001](')); // no link when url is empty
   });
 
-  it('deduplicates matches by id + package', () => {
+  it('deduplicates by id + package', () => {
     const json = JSON.stringify({
-      matches: [
-        { id: 'CVE-2025-1111', severity: 'High', package: 'cowboy', version: '2.10.0', fix_versions: ['2.12.0'], fix_state: 'fixed', url: 'https://example.com/1' },
-        { id: 'CVE-2025-1111', severity: 'High', package: 'cowboy', version: '2.10.0', fix_versions: ['2.12.0'], fix_state: 'fixed', url: 'https://example.com/2' },
-        { id: 'CVE-2025-2222', severity: 'Medium', package: 'ranch', version: '1.8.0', fix_versions: [], fix_state: 'not-fixed', url: '' },
+      vulnerabilities: [
+        { id: 'CVE-2025-1111', severity: 'High', package: 'cowboy', version: '2.10.0', fixed_version: '2.12.0', url: 'https://example.com/1' },
+        { id: 'CVE-2025-1111', severity: 'High', package: 'cowboy', version: '2.10.0', fixed_version: '2.12.0', url: 'https://example.com/2' },
+        { id: 'CVE-2025-2222', severity: 'Medium', package: 'ranch', version: '1.8.0', fixed_version: '', url: '' },
       ]
     });
     const lines = renderSbomSection(json);
@@ -134,10 +132,10 @@ describe('renderSbomSection', () => {
 
   it('renders multiple severities', () => {
     const json = JSON.stringify({
-      matches: [
-        { id: 'CVE-1', severity: 'Critical', package: 'a', version: '1.0', fix_versions: [], fix_state: 'unknown', url: '' },
-        { id: 'CVE-2', severity: 'Low', package: 'b', version: '2.0', fix_versions: ['2.1'], fix_state: 'fixed', url: '' },
-        { id: 'CVE-3', severity: 'Negligible', package: 'c', version: '3.0', fix_versions: [], fix_state: 'unknown', url: '' },
+      vulnerabilities: [
+        { id: 'CVE-1', severity: 'Critical', package: 'a', version: '1.0', fixed_version: '', url: '' },
+        { id: 'CVE-2', severity: 'Low', package: 'b', version: '2.0', fixed_version: '2.1', url: '' },
+        { id: 'CVE-3', severity: 'Negligible', package: 'c', version: '3.0', fixed_version: '', url: '' },
       ]
     });
     const lines = renderSbomSection(json);
@@ -165,7 +163,7 @@ describe('renderSummary', () => {
   });
 
   it('renders sbom only', () => {
-    const sbom = JSON.stringify({ matches: [] });
+    const sbom = JSON.stringify({ vulnerabilities: [] });
     const result = renderSummary({ sbom });
     assert.ok(result.startsWith('<!-- erlang-ci-summary -->'));
     assert.ok(result.includes(':package:'));
@@ -175,7 +173,7 @@ describe('renderSummary', () => {
 
   it('renders both with separator', () => {
     const audit = JSON.stringify({ vulnerabilities: [], dependencies_scanned: 5 });
-    const sbom = JSON.stringify({ matches: [] });
+    const sbom = JSON.stringify({ vulnerabilities: [] });
     const result = renderSummary({ audit, sbom });
     assert.ok(result.startsWith('<!-- erlang-ci-summary -->'));
     assert.ok(result.includes(':shield:'));
@@ -185,14 +183,14 @@ describe('renderSummary', () => {
 
   it('includes marker exactly once', () => {
     const audit = JSON.stringify({ vulnerabilities: [], dependencies_scanned: 1 });
-    const sbom = JSON.stringify({ matches: [] });
+    const sbom = JSON.stringify({ vulnerabilities: [] });
     const result = renderSummary({ audit, sbom });
     const markerCount = (result.match(/<!-- erlang-ci-summary -->/g) || []).length;
     assert.equal(markerCount, 1);
   });
 
   it('skips section with invalid JSON', () => {
-    const sbom = JSON.stringify({ matches: [] });
+    const sbom = JSON.stringify({ vulnerabilities: [] });
     const result = renderSummary({ audit: 'broken', sbom });
     assert.ok(result.includes(':package:'));
     assert.ok(!result.includes(':shield:'));


### PR DESCRIPTION
## Summary
- Replace `anchore/scan-action` (Grype) with `aquasecurity/trivy-action` for SBOM vulnerability scanning
- Update summary script and tests for Trivy's JSON output format
- Trivy has better CPE matching accuracy, reducing false positives for Erlang/OTP CVEs
- Supports `.trivyignore` files for per-repo false positive suppression

## Test plan
- [x] All 19 ci-summary unit tests pass
- [ ] CI passes (unit tests, lint, security scan)
- [ ] Verify Trivy scans CycloneDX SBOM correctly in downstream project (kura)