### PR TITLE
fix: handle curl|bash for generate-trivyignore

### DIFF
--- a/scripts/generate-trivyignore.sh
+++ b/scripts/generate-trivyignore.sh
@@ -157,7 +157,7 @@ generate_trivyignore() {
     echo "$output"
 }
 
-# When sourced, export functions only. When run directly, generate the file.
-if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+# When sourced, export functions only. When run directly or piped, generate the file.
+if [ -z "${BASH_SOURCE[0]:-}" ] || [ "${BASH_SOURCE[0]}" = "$0" ]; then
     generate_trivyignore
 fi


### PR DESCRIPTION
## Summary
- Fix `BASH_SOURCE[0]: unbound variable` when script is piped via `curl | bash`
- Guard with `${BASH_SOURCE[0]:-}` default value

## Test plan
- [x] Unit tests pass
- [ ] CI passes