### PR TITLE
feat: add coverage summary to PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,12 @@ jobs:
       - name: Generate coverage
         if: ${{ inputs.enable-coverage }}
         run: rebar3 covertool generate
-      - name: Upload coverage
+      - name: Upload coverage artifact
         if: ${{ inputs.enable-coverage }}
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          files: _build/test/covertool/*.covertool.xml
-          flags: eunit
+          name: coverage-eunit-otp${{ matrix.otp }}
+          path: _build/test/covertool/*.covertool.xml
 
   ct:
     name: Common Test${{ matrix.otp && format(' (OTP {0})', matrix.otp) || '' }}
@@ -379,12 +379,50 @@ jobs:
       - name: Generate coverage
         if: ${{ inputs.enable-coverage }}
         run: rebar3 covertool generate
-      - name: Upload coverage
+      - name: Upload coverage artifact
         if: ${{ inputs.enable-coverage }}
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          files: _build/test/covertool/*.covertool.xml
-          flags: ct
+          name: coverage-ct-otp${{ matrix.otp }}
+          path: _build/test/covertool/*.covertool.xml
+
+  coverage:
+    name: Coverage
+    needs: [eunit, ct]
+    if: ${{ always() && inputs.enable-coverage }}
+    runs-on: ubuntu-24.04
+    outputs:
+      json: ${{ steps.extract.outputs.json }}
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: coverage
+      - name: Extract coverage summary
+        id: extract
+        run: |
+          total_covered=0
+          total_valid=0
+          for f in coverage/*.covertool.xml; do
+            [ -f "$f" ] || continue
+            covered=$(grep -o 'lines-covered="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')
+            valid=$(grep -o 'lines-valid="[0-9]*"' "$f" | head -1 | grep -o '[0-9]*')
+            total_covered=$((total_covered + ${covered:-0}))
+            total_valid=$((total_valid + ${valid:-0}))
+          done
+
+          if [ "$total_valid" -gt 0 ]; then
+            pct=$(awk "BEGIN {printf \"%.1f\", ($total_covered/$total_valid)*100}")
+          else
+            pct="0.0"
+          fi
+
+          echo "json<<COV_EOF" >> "$GITHUB_OUTPUT"
+          echo "{\"line_rate\":$pct,\"lines_covered\":$total_covered,\"lines_valid\":$total_valid}" >> "$GITHUB_OUTPUT"
+          echo "COV_EOF" >> "$GITHUB_OUTPUT"
+          echo "Coverage: $pct% ($total_covered/$total_valid lines)"
 
   sbom:
     name: SBOM
@@ -503,7 +541,7 @@ jobs:
   summary:
     name: Summary
     if: ${{ always() && inputs.enable-summary && github.event_name == 'pull_request' }}
-    needs: [audit, sbom]
+    needs: [audit, sbom, coverage]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -518,6 +556,7 @@ jobs:
           AUDIT_JSON: ${{ needs.audit.outputs.json }}
           SBOM_JSON: ${{ needs.sbom.outputs.scan-json }}
           IGNORED_JSON: ${{ needs.sbom.outputs.ignored-json }}
+          COVERAGE_JSON: ${{ needs.coverage.outputs.json }}
         with:
           script: |
             const { renderSummary } = require('./scripts/ci-summary');
@@ -525,6 +564,7 @@ jobs:
               audit: process.env.AUDIT_JSON,
               sbom: process.env.SBOM_JSON,
               ignored: process.env.IGNORED_JSON,
+              coverage: process.env.COVERAGE_JSON,
             });
             if (!body) return;
 

--- a/scripts/ci-summary.js
+++ b/scripts/ci-summary.js
@@ -137,20 +137,55 @@ function renderIgnoredSection(ignoredJson) {
   return lines;
 }
 
-function renderSummary({ audit, sbom, ignored } = {}) {
+function coverageBadge(pct) {
+  if (pct >= 90) return ':green_circle:';
+  if (pct >= 70) return ':yellow_circle:';
+  if (pct >= 50) return ':orange_circle:';
+  return ':red_circle:';
+}
+
+function renderCoverageSection(coverageJson) {
+  if (!coverageJson || !coverageJson.trim()) return null;
+
+  let cov;
+  try { cov = JSON.parse(coverageJson); } catch { return null; }
+
+  const pct = cov.line_rate;
+  if (pct === undefined || pct === null) return null;
+
+  const badge = coverageBadge(pct);
+  const covered = cov.lines_covered || 0;
+  const valid = cov.lines_valid || 0;
+
+  return [`### ${badge} Code Coverage — ${pct}%`, `${covered} of ${valid} lines covered.`];
+}
+
+function renderSummary({ audit, sbom, ignored, coverage } = {}) {
   const auditLines = renderAuditSection(audit);
   const sbomLines = renderSbomSection(sbom);
   const ignoredLines = renderIgnoredSection(ignored);
+  const coverageLines = renderCoverageSection(coverage);
 
-  if (!auditLines && !sbomLines && !ignoredLines) return null;
+  if (!auditLines && !sbomLines && !ignoredLines && !coverageLines) return null;
+
+  const sections = [];
+  if (coverageLines) sections.push(coverageLines);
+  if (auditLines) sections.push(auditLines);
+  if (sbomLines) {
+    const combined = [...sbomLines];
+    if (ignoredLines) {
+      combined.push('');
+      combined.push(...ignoredLines);
+    }
+    sections.push(combined);
+  } else if (ignoredLines) {
+    sections.push(ignoredLines);
+  }
 
   const lines = ['<!-- erlang-ci-summary -->'];
-  if (auditLines) lines.push(...auditLines);
-  if (auditLines && (sbomLines || ignoredLines)) lines.push('', '---', '');
-  if (sbomLines) lines.push(...sbomLines);
-  if (ignoredLines) {
-    lines.push('');
-    lines.push(...ignoredLines);
+  for (let i = 0; i < sections.length; i++) {
+    if (i > 0) lines.push('', '---', '');
+    lines.push(...sections[i]);
   }
 
   return lines.join('\n');
@@ -161,4 +196,4 @@ function renderAuditSummary(auditJson) {
   return renderSummary({ audit: auditJson });
 }
 
-module.exports = { renderAuditSummary, renderAuditSection, renderSbomSection, renderIgnoredSection, renderSummary };
+module.exports = { renderAuditSummary, renderAuditSection, renderSbomSection, renderIgnoredSection, renderCoverageSection, renderSummary };

--- a/scripts/ci-summary.test.js
+++ b/scripts/ci-summary.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { renderAuditSummary, renderAuditSection, renderSbomSection, renderIgnoredSection, renderSummary } = require('./ci-summary');
+const { renderAuditSummary, renderAuditSection, renderSbomSection, renderIgnoredSection, renderCoverageSection, renderSummary } = require('./ci-summary');
 
 describe('renderAuditSection', () => {
   it('returns null for empty input', () => {
@@ -186,6 +186,45 @@ describe('renderIgnoredSection', () => {
   });
 });
 
+describe('renderCoverageSection', () => {
+  it('returns null for empty input', () => {
+    assert.equal(renderCoverageSection(''), null);
+    assert.equal(renderCoverageSection(null), null);
+    assert.equal(renderCoverageSection('   '), null);
+  });
+
+  it('renders high coverage with green badge', () => {
+    const json = JSON.stringify({ line_rate: 92.5, lines_covered: 1285, lines_valid: 1390 });
+    const lines = renderCoverageSection(json);
+    const text = lines.join('\n');
+    assert.ok(text.includes(':green_circle:'));
+    assert.ok(text.includes('92.5%'));
+    assert.ok(text.includes('1285 of 1390 lines'));
+  });
+
+  it('renders medium coverage with yellow badge', () => {
+    const json = JSON.stringify({ line_rate: 75.0, lines_covered: 750, lines_valid: 1000 });
+    const lines = renderCoverageSection(json);
+    const text = lines.join('\n');
+    assert.ok(text.includes(':yellow_circle:'));
+    assert.ok(text.includes('75%'));
+  });
+
+  it('renders low coverage with orange badge', () => {
+    const json = JSON.stringify({ line_rate: 55.0, lines_covered: 55, lines_valid: 100 });
+    const lines = renderCoverageSection(json);
+    const text = lines.join('\n');
+    assert.ok(text.includes(':orange_circle:'));
+  });
+
+  it('renders very low coverage with red badge', () => {
+    const json = JSON.stringify({ line_rate: 30.0, lines_covered: 30, lines_valid: 100 });
+    const lines = renderCoverageSection(json);
+    const text = lines.join('\n');
+    assert.ok(text.includes(':red_circle:'));
+  });
+});
+
 describe('renderSummary', () => {
   it('returns null when no data', () => {
     assert.equal(renderSummary({}), null);
@@ -251,6 +290,24 @@ describe('renderSummary', () => {
     const result = renderSummary({ ignored });
     assert.ok(result.startsWith('<!-- erlang-ci-summary -->'));
     assert.ok(result.includes('1 OTP CVE auto-ignored'));
+  });
+
+  it('renders coverage section', () => {
+    const coverage = JSON.stringify({ line_rate: 85.3, lines_covered: 1285, lines_valid: 1506 });
+    const result = renderSummary({ coverage });
+    assert.ok(result.startsWith('<!-- erlang-ci-summary -->'));
+    assert.ok(result.includes('85.3%'));
+    assert.ok(result.includes(':yellow_circle:'));
+  });
+
+  it('renders coverage first then audit', () => {
+    const coverage = JSON.stringify({ line_rate: 95.0, lines_covered: 950, lines_valid: 1000 });
+    const audit = JSON.stringify({ vulnerabilities: [], dependencies_scanned: 5 });
+    const result = renderSummary({ audit, coverage });
+    const coveragePos = result.indexOf('95%');
+    const auditPos = result.indexOf(':shield:');
+    assert.ok(coveragePos < auditPos, 'coverage should appear before audit');
+    assert.ok(result.includes('---'));
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace Codecov upload with coverage artifact upload
- Add `coverage` job that merges covertool XML and extracts line coverage %
- Render coverage section in PR summary comment with color-coded badge
- Coverage appears first in the summary (before audit/sbom)

Badge thresholds: :green_circle: ≥90% | :yellow_circle: ≥70% | :orange_circle: ≥50% | :red_circle: <50%

## Test plan
- [x] 32 ci-summary unit tests pass
- [ ] CI passes
- [ ] Test on kura PR #44 with `enable-coverage: true`