### PR TITLE
fix: merge eunit+ct coverdata before generating report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,15 +327,12 @@ jobs:
           EUNIT_ARGS: ${{ inputs.eunit-args }}
           COVER_FLAG: ${{ inputs.enable-coverage && '--cover' || '' }}
         run: rebar3 eunit $EUNIT_ARGS $COVER_FLAG
-      - name: Generate coverage
-        if: ${{ inputs.enable-coverage }}
-        run: rebar3 covertool generate
-      - name: Upload coverage artifact
+      - name: Upload coverdata
         if: ${{ inputs.enable-coverage }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: coverage-eunit-otp${{ matrix.otp }}
-          path: _build/test/covertool/*.covertool.xml
+          name: coverdata-eunit-otp${{ matrix.otp }}
+          path: _build/test/cover/eunit.coverdata
 
   ct:
     name: Common Test${{ matrix.otp && format(' (OTP {0})', matrix.otp) || '' }}
@@ -376,15 +373,12 @@ jobs:
           CT_CONFIG: ${{ inputs.ct-config && format('--sys_config {0}', inputs.ct-config) || '' }}
           COVER_FLAG: ${{ inputs.enable-coverage && '--cover' || '' }}
         run: rebar3 ct $CT_ARGS $CT_CONFIG $COVER_FLAG
-      - name: Generate coverage
-        if: ${{ inputs.enable-coverage }}
-        run: rebar3 covertool generate
-      - name: Upload coverage artifact
+      - name: Upload coverdata
         if: ${{ inputs.enable-coverage }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: coverage-ct-otp${{ matrix.otp }}
-          path: _build/test/covertool/*.covertool.xml
+          name: coverdata-ct-otp${{ matrix.otp }}
+          path: _build/test/cover/ct.coverdata
 
   coverage:
     name: Coverage
@@ -394,18 +388,29 @@ jobs:
     outputs:
       json: ${{ steps.extract.outputs.json }}
     steps:
-      - name: Download coverage artifacts
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: Taure/erlang-ci@v1
+        with:
+          otp-version: ${{ inputs.otp-version }}
+          rebar3-version: ${{ inputs.rebar3-version }}
+          version-file: ${{ inputs.version-file }}
+          version-type: ${{ inputs.version-type }}
+      - name: Download coverdata artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          pattern: coverage-*
+          pattern: coverdata-*
           merge-multiple: true
-          path: coverage
+          path: _build/test/cover
+      - name: Merge coverdata and generate report
+        run: |
+          echo "Coverdata files:"
+          ls -la _build/test/cover/*.coverdata 2>/dev/null || echo "No coverdata files found"
+          rebar3 covertool generate
       - name: Extract coverage summary
         id: extract
         run: |
-          echo "Coverage artifacts:"
-          find coverage -name '*.covertool.xml' -ls 2>/dev/null || echo "No .covertool.xml files found"
-
           total_covered=0
           total_valid=0
           while IFS= read -r f; do
@@ -414,7 +419,7 @@ jobs:
             echo "  $f: covered=$covered valid=$valid"
             total_covered=$((total_covered + ${covered:-0}))
             total_valid=$((total_valid + ${valid:-0}))
-          done < <(find coverage -name '*.covertool.xml' 2>/dev/null)
+          done < <(find _build/test/covertool -name '*.covertool.xml' 2>/dev/null)
 
           if [ "$total_valid" -gt 0 ]; then
             pct=$(awk "BEGIN {printf \"%.1f\", ($total_covered/$total_valid)*100}")


### PR DESCRIPTION
## Summary
- Upload raw `.coverdata` files instead of covertool XML from eunit/ct jobs
- Coverage job downloads all coverdata, merges them via `rebar3 covertool generate`, then extracts the combined percentage
- Fixes 0% coverage caused by CT's `kura.covertool.xml` overwriting eunit's (same filename, `merge-multiple: true`)

## Test plan
- [ ] CI passes
- [ ] Kura shows actual coverage percentage in PR comment