### PR TITLE
fix: compile before coverage report generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,8 +403,9 @@ jobs:
           pattern: coverdata-*
           merge-multiple: true
           path: _build/test/cover
-      - name: Merge coverdata and generate report
+      - name: Compile and generate coverage report
         run: |
+          rebar3 compile
           echo "Coverdata files:"
           ls -la _build/test/cover/*.coverdata 2>/dev/null || echo "No coverdata files found"
           rebar3 covertool generate


### PR DESCRIPTION
Covertool needs compiled beams to resolve modules. Without compile, the coverage XML is empty (0 lines).