### PR TITLE
feat(audit): add audit-ignores input to skip non-applicable GHSA IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
           version-file: ${{ inputs.version-file }}
           version-type: ${{ inputs.version-type }}
           ssh-key: ${{ secrets.ssh-key }}
-      - uses: Taure/erlang-ci/audit@main
+      - uses: Taure/erlang-ci/audit@feat/audit-ignores
         id: audit
         with:
           level: ${{ inputs.audit-level }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,11 @@ on:
         type: string
         required: false
         default: 'low'
+      audit-ignores:
+        description: 'Whitespace- or comma-separated GHSA IDs to skip (no-patch advisories that do not apply to this project). Document each in SECURITY.md.'
+        type: string
+        required: false
+        default: ''
       enable-coverage:
         description: 'Enable code coverage (--cover flag + covertool)'
         type: boolean
@@ -384,6 +389,7 @@ jobs:
         id: audit
         with:
           level: ${{ inputs.audit-level }}
+          ignores: ${{ inputs.audit-ignores }}
 
   eunit:
     name: EUnit${{ matrix.otp && format(' (OTP {0})', matrix.otp) || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,11 @@ jobs:
         working-directory: test/fixtures
         run: rebar3 audit --format json --level low
 
+      # --- Audit with ignores (smoke-tests audit-ignores wiring) ---
+      - name: Audit with ignores
+        working-directory: test/fixtures
+        run: rebar3 audit --level low -i GHSA-xxxx-yyyy-zzzz -i GHSA-aaaa-bbbb-cccc
+
       # --- SBOM (mirrors ci.yml sbom job command) ---
       - name: SBOM generate
         working-directory: test/fixtures

--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ jobs:
 | `enable-ex-doc` | `false` | Run `rebar3 ex_doc` |
 | `enable-audit` | `false` | Run `rebar3 audit` (dep vulnerability scanning) |
 | `audit-level` | `low` | Minimum severity to fail on (`critical`, `high`, `medium`, `low`) |
+| `audit-ignores` | — | GHSA IDs to skip (space- or comma-separated). For unpatched advisories that do not apply; document each in SECURITY.md. |
 | `enable-coverage` | `false` | Coverage via covertool (reported in PR summary) |
 | `enable-sbom` | `false` | Generate CycloneDX SBOM via `rebar3 sbom` |
 | `enable-sbom-scan` | `false` | Scan SBOM for vulnerabilities using Trivy (requires `enable-sbom`) |
@@ -810,6 +811,14 @@ The badge color reflects coverage level: green (90%+), yellow (70%+), orange (50
 Each vulnerability includes an expandable details section with the full description and vulnerable version range.
 
 The `audit-level` input controls the minimum severity that causes the job to fail (default: `low` — all vulnerabilities fail the build). Set to `high` or `critical` to allow lower-severity issues to pass.
+
+The `audit-ignores` input lists GHSA IDs to skip. Use it sparingly, only for advisories that have no upstream patch and that genuinely do not apply to your code (e.g. a vulnerable function your project never calls). Each entry should be documented in `SECURITY.md` or an audit report with the justification.
+
+```yaml
+with:
+  enable-audit: true
+  audit-ignores: 'GHSA-g2wm-735q-3f56 GHSA-xxxx-yyyy-zzzz'
+```
 
 ### SBOM Scan (`enable-sbom-scan`)
 

--- a/audit/action.yml
+++ b/audit/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'Minimum severity to fail on (critical, high, medium, low)'
     required: false
     default: 'low'
+  ignores:
+    description: 'Whitespace- or comma-separated GHSA IDs to skip (e.g. "GHSA-xxxx-yyyy-zzzz GHSA-aaaa-bbbb-cccc"). Use for advisories that have no upstream patch and do not apply to this project. Document each entry in SECURITY.md or an audit doc.'
+    required: false
+    default: ''
 
 outputs:
   json:
@@ -21,5 +25,12 @@ runs:
       shell: bash
       env:
         AUDIT_LEVEL: ${{ inputs.level }}
+        AUDIT_IGNORES: ${{ inputs.ignores }}
       run: |
-        rebar3 audit --level "$AUDIT_LEVEL"
+        ignore_args=()
+        if [ -n "$AUDIT_IGNORES" ]; then
+          for ghsa in $(echo "$AUDIT_IGNORES" | tr ',' ' '); do
+            ignore_args+=(-i "$ghsa")
+          done
+        fi
+        rebar3 audit --level "$AUDIT_LEVEL" "${ignore_args[@]}"


### PR DESCRIPTION
## Summary
Adds an \`audit-ignores\` input to the reusable \`ci.yml\` and the audit composite action. Whitespace- or comma-separated GHSA IDs are converted into \`rebar3 audit -i <GHSA>\` flags so projects can accept advisories that have no upstream patch and that do not apply to their call paths.

Previously, projects had to either pin a lower \`audit-level\` (hiding all LOW/MEDIUM advisories) or live with red CI indefinitely. This input lets projects skip specific advisories without losing visibility on everything else.

## Usage

\`\`\`yaml
with:
  enable-audit: true
  audit-ignores: 'GHSA-g2wm-735q-3f56 GHSA-xxxx-yyyy-zzzz'
\`\`\`

Each entry should be documented in the project's \`SECURITY.md\` or an audit doc with the justification.

## Test plan
- [x] README updated with the new input
- [x] \`test.yml\` smoke-tests the underlying \`rebar3 audit -i ...\` flag syntax against the test fixture
- [x] actionlint clean (CI will verify)