### PR TITLE
ci: repoint audit composite from feat branch back to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
           version-file: ${{ inputs.version-file }}
           version-type: ${{ inputs.version-type }}
           ssh-key: ${{ secrets.ssh-key }}
-      - uses: Taure/erlang-ci/audit@feat/audit-ignores
+      - uses: Taure/erlang-ci/audit@main
         id: audit
         with:
           level: ${{ inputs.audit-level }}


### PR DESCRIPTION
Follow-up to #62 — the temporary `@feat/audit-ignores` pin in ci.yml is dangling now that the branch is deleted. Repoint to `@main`, which has the audit-ignores input since #62 merged.