### PR TITLE
fix: fail fast when rebar3 audit hangs (job + command timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,7 @@ jobs:
     needs: compile
     if: ${{ inputs.enable-audit }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     env:
       HEX_API_KEY: ${{ secrets.hex-api-key }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/audit/action.yml
+++ b/audit/action.yml
@@ -33,4 +33,12 @@ runs:
             ignore_args+=(-i "$ghsa")
           done
         fi
-        rebar3 audit --level "$AUDIT_LEVEL" "${ignore_args[@]}"
+        set +e
+        timeout "${AUDIT_TIMEOUT:-300}" rebar3 audit --level "$AUDIT_LEVEL" "${ignore_args[@]}"
+        status=$?
+        set -e
+        if [ "$status" -eq 124 ]; then
+          echo "::error::rebar3 audit timed out after ${AUDIT_TIMEOUT:-300}s - the advisory database is likely unreachable. Failing closed; re-run once the source recovers." >&2
+          exit 1
+        fi
+        exit "$status"


### PR DESCRIPTION
Closes #65.

The `audit` job ran `rebar3 audit` with no timeout, so a stalled advisory-DB fetch left the job running to GitHub's 6h default and blocked merges. Observed on `asobi_site`: ~20+ min hang, every other job green, on a docs-only change (Audit had passed on 2026-07-07 — external advisory-source flakiness, not a finding).

## Changes
- **`audit/action.yml`**: wrap `rebar3 audit` in `timeout` (default 300s, overridable via `AUDIT_TIMEOUT`). On timeout, fail closed with a clear `::error::` instead of hanging. Reaches all consumers immediately since the workflow calls `audit@main`.
- **`ci.yml`**: `timeout-minutes: 10` backstop on the `audit` job (lands downstream on the next release + pin bump).

**Fails closed** — a timed-out audit never silently passes as verified.

## Verification
- Both YAML files parse.
- Timeout branch logic exercised locally: exit 124 → clear message → `exit 1`; other exits propagate unchanged.

Follow-ups (in #65): promote `AUDIT_TIMEOUT` to a workflow input, optional single retry, check whether `rebar3_audit` has a native network timeout, then release + bump downstream pins.