### PR TITLE
fix: authenticate rebar3 audit advisory API with the workflow token

### DIFF
--- a/audit/action.yml
+++ b/audit/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Whitespace- or comma-separated GHSA IDs to skip (e.g. "GHSA-xxxx-yyyy-zzzz GHSA-aaaa-bbbb-cccc"). Use for advisories that have no upstream patch and do not apply to this project. Document each entry in SECURITY.md or an audit doc.'
     required: false
     default: ''
+  token:
+    description: 'GitHub token used to authenticate advisory API requests. Without it the GitHub advisories API is limited to 60 requests/hour per IP, which rate-limits the audit. Defaults to the automatic workflow token.'
+    required: false
+    default: ${{ github.token }}
 
 outputs:
   json:
@@ -26,6 +30,7 @@ runs:
       env:
         AUDIT_LEVEL: ${{ inputs.level }}
         AUDIT_IGNORES: ${{ inputs.ignores }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         ignore_args=()
         if [ -n "$AUDIT_IGNORES" ]; then


### PR DESCRIPTION
### Problem
The `audit` composite action runs `rebar3 audit` without `GITHUB_TOKEN` in the step env. The step's `env:` block only carried `AUDIT_LEVEL` and `AUDIT_IGNORES`, so the token set at the reusable workflow's job level never reached the composite step. `rebar3_audit` resolves its token from `os:getenv("GITHUB_TOKEN")`, so it fell back to **unauthenticated** GitHub API access.

The advisories endpoint (`https://api.github.com/advisories?ecosystem=erlang`) is **60 requests/hour per IP** unauthenticated. The plugin paginates the whole Erlang advisory list, so back-to-back audit runs exhaust that budget; the API then returns 403 / closes the connection (`{error, rate_limited}` / `{error, shutdown}`), and the job fails closed on the 300s timeout with the misleading "advisory database is likely unreachable" message.

### Fix
Add an optional `token` input (default `${{ github.token }}`) and forward it as `GITHUB_TOKEN` into the step env. Authenticated requests get 5000/hour, so a single repo's audit never rate-limits.

Backward-compatible: the input defaults to the automatic workflow token, so existing callers need no change.

### Verified
`api.github.com/advisories` unauthenticated: one clean call, then `rate_limited` on the next — the 60/hour signature. Reproduced against asobi_engine and asobi_lua CI (both timed out); asobi passed only by hitting a fresh budget window.