### PR TITLE
fix: drop cached plugins so rebar.config pin changes are not shadowed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,12 @@ runs:
       shell: bash
       run: |
         find _build -name "*.bea#" -delete 2>/dev/null || true
+        # Plugins live in _build/*/plugins and are pinned in rebar.config, not
+        # rebar.lock (the build-cache key). A restored cache - including the
+        # restore-keys prefix fallback - can therefore carry a plugin that no
+        # longer matches the pin, and rebar3 will not re-resolve a plugin that is
+        # already present. Drop them so the current rebar.config pins always win.
+        rm -rf _build/*/plugins 2>/dev/null || true
         # Clean project app compile artifacts (preserves dep cache)
         # Prevents parse transform .bea# failures with stale cached state
         rebar3 clean 2>/dev/null || true


### PR DESCRIPTION
### Problem
The build cache key hashes `rebar.lock`:
```
key: ...-build-...-${{ hashFiles('rebar.lock') }}
```
But plugins are pinned in **`rebar.config`** (`project_plugins`) and live in `_build/*/plugins`. So:
1. Changing a plugin pin does not change `rebar.lock`, so the exact key still hits.
2. Even when the key misses, the `restore-keys` prefix fallback restores an older `_build` anyway.
3. rebar3 will **not** re-resolve a plugin that is already present in `_build`.

Net effect: a changed plugin pin is silently shadowed by the stale cached plugin. This bit asobi_engine — a `rebar3_audit` pin bump to a fixed version kept running the old buggy plugin from cache (paginated `page=N` against a cursor-only endpoint → 300s hang), until the caches were manually deleted.

### Fix
Drop `_build/*/plugins` in the existing "Clean stale compile artifacts" step so rebar3 re-resolves plugins from the current `rebar.config` every run. Plugin git checkouts are still cached in `~/.cache/rebar3` (keyed on `rebar.config`), so this is a cheap re-copy/recompile, not a network refetch.

Targeted, minimal, and correctness-first: the plugin set now always matches the pins, and app/dep compile caching is untouched.